### PR TITLE
Add implied port

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -16,7 +16,12 @@ for category in servers_config:
     for server in servers_config[category]:
         print "- " + server + ": " + servers_config[category][server]
         ip = servers_config[category][server]
-        status = mcstatus.McServer(ip.split("/")[0], int(ip.split("/")[1]))
+        if "/" in ip:
+            port = ip.split("/")[1]
+            ip = ip.split("/")[0]
+        else:
+            port = 25565
+        status = mcstatus.McServer(ip, int(port))
         c += 1
         data[category][server] = status
 


### PR DESCRIPTION
TL;DR: See code

**The Issue:**
Currently, if you don't specify a port after your address, the script fails with an exception. However, if you run servers on the default port, you would probably expect the script to behave like Vanilla Minecraft and imply the port to the default.
**PR Breakdown:**
This PR implies the port to 25565 (default Minecraft port) if no port is given. (aka. the ip string does not have a slash)
It does that by checking if the IP string contains a `/` - If it does, the string is split into port and ip parts. If it does not, the port is defaulted to the Minecraft default.
**PR testing materials:**
[Ideone syntax and logic test of the changed lines](http://ideone.com/17OzFc) 
The above test tests the logic and syntax of the modified code.

Thanks!
